### PR TITLE
WIP: send multiple queries in single request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ ENV/
 *.iml
 
 /requirements.txt
+/requirements.in

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Poetry can export the requirements
     
 A few more libraries are required to run the tests
 
+    pip install pytest
     pip install wheel
     pip install responses
     pip install flask

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -2,12 +2,15 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import json
 from io import StringIO as IO
+from threading import Thread
+from time import sleep
 
+import responses
 import yaml
 
-from adr import config
+from adr import config, configuration
 from adr import query
-from adr.query import format_query
+from adr.query import format_query, query_activedata
 
 
 class RunQuery(object):
@@ -15,17 +18,19 @@ class RunQuery(object):
         self.query_test = query_test
 
     def __call__(self, query, *args, **kwargs):
-        return self.query_test['mock_data']
+        return self.query_test["mock_data"]
 
 
 def test_query(monkeypatch, query_test, set_config):
-    set_config(**{
-        'query': query_test['query'],
-        'fmt': 'json',
-        'debug': False,
-        'debug_url': "https://activedata.allizom.org/tools/query.html#query_id={}",
-    })
-    monkeypatch.setattr(query, 'query_activedata', RunQuery(query_test))
+    set_config(
+        **{
+            "query": query_test["query"],
+            "fmt": "json",
+            "debug": False,
+            "debug_url": "https://activedata.allizom.org/tools/query.html#query_id={}",
+        }
+    )
+    monkeypatch.setattr(query, "query_activedata", RunQuery(query_test))
 
     def print_diff():
 
@@ -35,30 +40,31 @@ def test_query(monkeypatch, query_test, set_config):
         print(buf.getvalue())
 
         buf = IO()
-        yaml.dump(query_test['expected'], buf)
+        yaml.dump(query_test["expected"], buf)
         print("\nYaml formatted expected:")
         print(buf.getvalue())
 
     if "--debug" in query_test["args"]:
 
         set_config(debug=True)
-        monkeypatch.setattr(query, 'query_activedata', RunQuery(query_test))
+        monkeypatch.setattr(query, "query_activedata", RunQuery(query_test))
 
-        formatted_query = format_query(query_test['query'])
+        formatted_query = format_query(query_test["query"])
         result = json.loads(formatted_query[0])
         debug_url = formatted_query[1]
 
         print_diff()
         assert result == query_test["expected"]
         assert debug_url == config.debug_url.format(
-            query_test["expected"]["meta"]["saved_as"])
+            query_test["expected"]["meta"]["saved_as"]
+        )
 
     elif "--table" in query_test["args"]:
 
-        set_config(fmt='table')
-        monkeypatch.setattr(query, 'query_activedata', RunQuery(query_test))
+        set_config(fmt="table")
+        monkeypatch.setattr(query, "query_activedata", RunQuery(query_test))
 
-        formatted_query = format_query(query_test['query'])
+        formatted_query = format_query(query_test["query"])
         result = formatted_query[0]
         debug_url = formatted_query[1]
         expected = query_test["expected"]["data"]
@@ -72,10 +78,41 @@ def test_query(monkeypatch, query_test, set_config):
 
     else:
 
-        formatted_query = format_query(query_test['query'])
+        formatted_query = format_query(query_test["query"])
         result = json.loads(formatted_query[0])
         debug_url = formatted_query[1]
 
         print_diff()
         assert result == query_test["expected"]
         assert debug_url is None
+
+
+@responses.activate
+def test_threaded_query():
+    url = configuration.config.url
+    dummy_query = json.dumps({"from": "dummy"})
+
+    def request_callback(request):
+        payload = json.loads(request.body)
+        many_queries = payload.get("tuple")
+        if many_queries is None:
+            # THE FIRST QUERY WILL TAKE A WHILE, SO THE OTHER THREADS WILL FILL activedata_work_items
+            sleep(1)
+            return 200, {}, json.dumps("x")
+        assert len(many_queries) == 3
+        return 200, {}, json.dumps({"data": ["a", "b", "c"]})
+
+    responses.add_callback(responses.POST, url, callback=request_callback)
+
+    result = [None] * 4
+
+    def requestor(i):
+        result[i] = query_activedata(dummy_query, url)
+
+    threads = [Thread(target=requestor, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert result == ["x", "a", "b", "c"]


### PR DESCRIPTION
ActiveData will soon be accepting `{"tuple":[]}` requests, which accepts a list of of disparate queries.  The hope is some multithreading the disparate queries on the server side will be a little faster in aggregate, especially if the queries hit the same columns.